### PR TITLE
Add endpoint to get league standings

### DIFF
--- a/controllers/teamController.js
+++ b/controllers/teamController.js
@@ -130,6 +130,19 @@ const getTeamWithPlayers = async function (req, res) {
     }
 };
 
+const getLeagueStandings = async (req, res) => {
+    try {
+        const teams = await Team.find({}).sort({ points: -1 });
+        res.send(teams);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send({
+            message: "An error occurred while retrieving the league standings. Please try again later.",
+            error: err.message
+        });
+    }
+};
+
 export {
     teamsWithPlayers,
     getAllTeams,
@@ -138,5 +151,6 @@ export {
     deleteTeam,
     updateTeam,
     getTeam,
-    getTeamWithPlayers
+    getTeamWithPlayers,
+    getLeagueStandings
 };

--- a/routers/teamRouter.js
+++ b/routers/teamRouter.js
@@ -7,7 +7,8 @@ import {
     getAllTeams,
     getTeamWithPlayers,
     teamsWithPlayers,
-    getTeamsWithNoStadium
+    getTeamsWithNoStadium,
+    getLeagueStandings
 } from "../controllers/teamController.js";
 import {authenticateToken} from '../controllers/apiSecurityController.js';
 
@@ -164,5 +165,17 @@ router.delete('/team/:id', deleteTeam);
  *         description: Team updated
  */
 router.patch('/team/:id', updateTeam);
+
+/**
+ * @swagger
+ * /leagueStandings:
+ *   get:
+ *     summary: Retrieve the league standings by points
+ *     tags: [Teams]
+ *     responses:
+ *       200:
+ *         description: League standings by points
+ */
+router.get("/leagueStandings", getLeagueStandings);
 
 export default router;

--- a/swagger.js
+++ b/swagger.js
@@ -20,6 +20,7 @@ const options = {
             {name: 'Players', description: 'Endpoints related to players'},
             {name: 'Admin Users', description: 'Endpoints related to admin users'},
             {name: 'Commentators', description: 'Endpoints related to commentators'},
+            {name: 'League Standings', description: 'Endpoints related to league standings'},
         ],
     },
     apis: ['./routers/*.js'], // Path to the API docs


### PR DESCRIPTION
Add a new endpoint to get the standings of the league table by points for each team.

* **controllers/teamController.js**
  - Add a new function `getLeagueStandings` to fetch the standings of the league table by points for each team.
  - Sort the teams by points in descending order.

* **routers/teamRouter.js**
  - Add a new route `/leagueStandings` to handle the request for the league standings.
  - Use the `getLeagueStandings` function from `teamController.js`.

* **swagger.js**
  - Update the Swagger documentation to include the new endpoint for the league standings.
  - Add a new tag for the league standings endpoint.

